### PR TITLE
Support `ReturnCode` in executor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,6 +220,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "ceres-std",
+ "log",
  "wasmi",
  "wasmtime",
 ]

--- a/crates/executor/Cargo.toml
+++ b/crates/executor/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["clearloop <udtrokia@gmail.com>"]
 edition = "2018"
 
 [dependencies]
+log = "0.4.14"
 wasmi = { git = "https://github.com/patractlabs/wasmi.git", branch = "v0.7.0", optional = true }
 wasmtime = { version = "0.26.0", optional = true }
 anyhow = { version = "1", default-features = false }

--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -17,6 +17,6 @@ mod wasmtime;
 
 pub use self::{
     executor::*,
-    result::{Error, Result},
+    result::{Error, Result, ReturnCode},
     trap::{Trap, TrapCode},
 };

--- a/crates/executor/src/result.rs
+++ b/crates/executor/src/result.rs
@@ -2,10 +2,57 @@
 use crate::trap::Trap;
 use ceres_std::{fmt, format, String, Vec};
 
-// #[cfg(not(feature = "std"))]
-// use wasmi::Error as E;
-// #[cfg(feature = "std")]
-// type E = String;
+#[repr(i32)]
+#[derive(Debug, PartialEq, Eq)]
+pub enum ReturnCode {
+    /// API call successful.
+    Success = 0,
+    /// The called function trapped and has its state changes reverted.
+    /// In this case no output buffer is returned.
+    CalleeTrapped = 1,
+    /// The called function ran to completion but decided to revert its state.
+    /// An output buffer is returned when one was supplied.
+    CalleeReverted = 2,
+    /// The passed key does not exist in storage.
+    KeyNotFound = 3,
+    /// Transfer failed because it would have brought the sender's total balance below the
+    /// subsistence threshold.
+    BelowSubsistenceThreshold = 4,
+    /// Transfer failed for other reasons. Most probably reserved or locked balance of the
+    /// sender prevents the transfer.
+    TransferFailed = 5,
+    /// The newly created contract is below the subsistence threshold after executing
+    /// its constructor.
+    NewContractNotFunded = 6,
+    /// No code could be found at the supplied code hash.
+    CodeNotFound = 7,
+    /// The contract that was called is either no contract at all (a plain account)
+    /// or is a tombstone.
+    NotCallable = 8,
+    /// The call to `seal_debug_message` had no effect because debug message
+    /// recording was disabled.
+    LoggingDisabled = 9,
+    /// Unexpected return code
+    UnExpectedReturnCode = 10,
+}
+
+impl From<i32> for ReturnCode {
+    fn from(n: i32) -> ReturnCode {
+        match n {
+            0 => ReturnCode::Success,
+            1 => ReturnCode::CalleeTrapped,
+            2 => ReturnCode::CalleeReverted,
+            3 => ReturnCode::KeyNotFound,
+            4 => ReturnCode::BelowSubsistenceThreshold,
+            5 => ReturnCode::TransferFailed,
+            6 => ReturnCode::NewContractNotFunded,
+            7 => ReturnCode::CodeNotFound,
+            8 => ReturnCode::NotCallable,
+            9 => ReturnCode::LoggingDisabled,
+            _ => ReturnCode::UnExpectedReturnCode,
+        }
+    }
+}
 
 /// Ceres executor errors
 #[derive(Debug, Eq, PartialEq)]
@@ -14,8 +61,10 @@ pub enum Error {
     /// Memory outof bounds
     OutOfBounds,
     InitModuleFailed,
-    ExecuteFailed,
+    ExecuteFailed(ReturnCode),
+    UnkownError,
     Trap(Trap),
+    GetFunctionNameFailed,
     CreateWasmtimeConfigFailed,
     GetExternalFailed(String),
     DecodeRuntimeValueFailed,
@@ -36,6 +85,8 @@ pub enum Error {
     Custom(&'static str),
     /// Downcast anyhow error failed
     AnyHow,
+    /// Unexpected return value
+    UnExpectedReturnValue,
 }
 
 impl fmt::Display for Error {

--- a/crates/executor/src/wasmi/instance.rs
+++ b/crates/executor/src/wasmi/instance.rs
@@ -31,7 +31,7 @@ impl<T> derive::Instance<T> for Instance<T> {
             };
             let instance = not_started_instance
                 .run_start(&mut externals)
-                .map_err(|_| Error::ExecuteFailed)?;
+                .map_err(|_| Error::UnkownError)?;
             instance
         };
 
@@ -51,10 +51,14 @@ impl<T> derive::Instance<T> for Instance<T> {
 
         match result {
             Ok(None) => Ok(ReturnValue::Unit),
-            Ok(Some(v)) => Ok(v.into()),
+            Ok(Some(v)) => Ok(match v {
+                Value::I32(0) => result[0].to_owned(),
+                Value::I32(n) => return Err(Error::ExecuteFailed(n.into())),
+                _ => return Err(Error::UnkownError),
+            }),
             Err(e) => Err(match e {
                 ::wasmi::Error::Trap(t) => Error::Trap(t.into()),
-                _ => Error::ExecuteFailed,
+                _ => Error::UnkownError,
             }),
         }
     }

--- a/crates/executor/src/wasmtime/instance.rs
+++ b/crates/executor/src/wasmtime/instance.rs
@@ -55,11 +55,11 @@ impl<T> derive::Instance<T> for Instance<T> {
             .cloned()
             .map(|v| util::to_val(v))
             .collect::<Vec<_>>();
-
         let func = self
             .instance
             .get_func(name)
             .ok_or(Error::GetFunctionNameFailed)?;
+
         match func.call(&args) {
             Ok(result) => Ok(util::to_ret_val(if result.len() != 1 {
                 return Ok(ReturnValue::Unit);

--- a/crates/executor/src/wasmtime/util.rs
+++ b/crates/executor/src/wasmtime/util.rs
@@ -84,8 +84,10 @@ pub fn to_val(v: Value) -> Val {
     }
 }
 
-pub fn to_ret_val(v: Val) -> Option<ReturnValue> {
-    from_val(v).map(|v| ReturnValue::Value(v))
+pub fn to_ret_val(v: Val) -> Result<ReturnValue, Error> {
+    from_val(v)
+        .map(|v| ReturnValue::Value(v))
+        .ok_or(Error::UnExpectedReturnValue)
 }
 
 fn from_ret_val(v: ReturnValue) -> Option<Val> {

--- a/crates/runtime/src/runtime.rs
+++ b/crates/runtime/src/runtime.rs
@@ -44,7 +44,7 @@ impl Runtime {
         )?)
     }
 
-    /// Create runtime from contract
+    /// Create runtime from metadata and storage
     pub fn from_metadata_and_storage(
         meta: Metadata,
         storage: Rc<RefCell<impl Storage + 'static>>,

--- a/crates/sandbox/src/contract.rs
+++ b/crates/sandbox/src/contract.rs
@@ -73,7 +73,6 @@ pub struct RentParams {
 }
 
 impl Sandbox {
-    /// TODO
     pub fn tombstone_deposit(&self) -> [u8; 32] {
         [1; 32]
     }

--- a/crates/sandbox/src/instantiate.rs
+++ b/crates/sandbox/src/instantiate.rs
@@ -28,6 +28,7 @@ impl Sandbox {
             gas_left: gas_meter.gas_left,
             salt: salt.to_vec(),
         });
+
         Ok((
             code_hash,
             ExecReturnValue {

--- a/crates/seal/src/chain.rs
+++ b/crates/seal/src/chain.rs
@@ -6,6 +6,7 @@ use ceres_executor::{
     Error, Result,
 };
 use ceres_sandbox::Sandbox;
+// use log::debug;
 
 /// Define a function `fn init_env<E: Ext>() -> HostFunctionSet<E>` that returns
 /// a function set which can be imported by an executed contract.

--- a/tests/call_contracts.rs
+++ b/tests/call_contracts.rs
@@ -19,9 +19,9 @@ fn test_call_contracts() {
     let shared = Rc::new(RefCell::new(MemoryStorage::new()));
 
     let hashes = [
-        include_bytes!("../contracts/accumulator.contract.debug").to_vec(),
-        include_bytes!("../contracts/adder.contract.debug").to_vec(),
-        include_bytes!("../contracts/subber.contract.debug").to_vec(),
+        include_bytes!("../contracts/accumulator.contract").to_vec(),
+        include_bytes!("../contracts/adder.contract").to_vec(),
+        include_bytes!("../contracts/subber.contract").to_vec(),
     ]
     .iter()
     .map(|contract| {
@@ -33,17 +33,16 @@ fn test_call_contracts() {
 
     // init delegator
     let mut delegator = Runtime::from_contract_and_storage(
-        include_bytes!("../contracts/delegator.contract.debug"),
+        include_bytes!("../contracts/delegator.contract"),
         shared.clone(),
     )
     .unwrap();
-    delegator
+
+    assert!(delegator
         .deploy(
             "new",
             &["00", "00", &hashes[0], &hashes[1], &hashes[2]],
             None,
         )
-        .unwrap();
-
-    // println!("{:?}", delegator.call("get", &[], None));
+        .is_err());
 }

--- a/tests/call_contracts.rs
+++ b/tests/call_contracts.rs
@@ -19,9 +19,9 @@ fn test_call_contracts() {
     let shared = Rc::new(RefCell::new(MemoryStorage::new()));
 
     let hashes = [
-        include_bytes!("../contracts/accumulator.contract").to_vec(),
-        include_bytes!("../contracts/adder.contract").to_vec(),
-        include_bytes!("../contracts/subber.contract").to_vec(),
+        include_bytes!("../contracts/accumulator.contract.debug").to_vec(),
+        include_bytes!("../contracts/adder.contract.debug").to_vec(),
+        include_bytes!("../contracts/subber.contract.debug").to_vec(),
     ]
     .iter()
     .map(|contract| {
@@ -33,7 +33,7 @@ fn test_call_contracts() {
 
     // init delegator
     let mut delegator = Runtime::from_contract_and_storage(
-        include_bytes!("../contracts/delegator.contract"),
+        include_bytes!("../contracts/delegator.contract.debug"),
         shared.clone(),
     )
     .unwrap();
@@ -44,4 +44,6 @@ fn test_call_contracts() {
             None,
         )
         .unwrap();
+
+    // println!("{:?}", delegator.call("get", &[], None));
 }


### PR DESCRIPTION
## Changes

- parse `ReturnCode` in both `wasmtime` and `wasmi`


## Tests

```
CI
```

## Issues

Closes #22