### PR TITLE
Fix/issue 49

### DIFF
--- a/crates/executor/src/wasmtime/instance.rs
+++ b/crates/executor/src/wasmtime/instance.rs
@@ -61,6 +61,7 @@ impl<T> derive::Instance<T> for Instance<T> {
             } else {
                 match result[0] {
                     Val::I32(0) => result[0].to_owned(),
+                    // FIXME: test_number_and_hash_with_numbers, Val::I32(7)
                     Val::I32(n) => return Err(Error::ExecuteFailed(n.into())),
                     _ => return Err(Error::UnkownError),
                 }

--- a/crates/runtime/src/runtime.rs
+++ b/crates/runtime/src/runtime.rs
@@ -108,7 +108,7 @@ impl Runtime {
         // Create instance
         let instance = Instance::new(
             &el.to_bytes()
-                .map_err(|error| Error::SerializeFailed { error })?,
+                .map_err(|error| Error::SerializeFailed { error: error.into() })?,
             &builder,
             &mut sandbox.borrow_mut(),
         )

--- a/crates/runtime/src/util.rs
+++ b/crates/runtime/src/util.rs
@@ -14,6 +14,8 @@ pub fn parse_args(selector: &str, args: Vec<Vec<u8>>, tys: Vec<u32>) -> Result<V
         });
     }
 
+    // TODO: Arguments Type Check
+
     let mut res = step_hex(selector)
         .map_err(|_| Error::DecodeSelectorFailed)?
         .to_vec();

--- a/tests/args.rs
+++ b/tests/args.rs
@@ -142,9 +142,8 @@ fn test_all() {
 fn test_number_and_hash_with_numbers() {
     t(|args: &mut Runtime| {
         assert_eq!(
-            args.call("test_number_and_hash", vec![0.encode(), 1.encode()], None)
-                .unwrap(),
-            ceres_runtime::Error::DecodeRuntimeValueFailed
+            args.call("test_number_and_hash", vec![0.encode(), 1.encode()], None),
+            Err(ceres_runtime::Error::DecodeRuntimeValueFailed)
         );
     })
 }


### PR DESCRIPTION
Should have the best way to do type check of the arguments passed to `Runtime::call`.